### PR TITLE
test chevalier against go 1.4.1 with travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.2
+  - 1.4.1
 
 install:
   - ./bin/install_deps.sh


### PR DESCRIPTION
Update .travis.yml to test against 1.4.1, so we can make sure docker-chevalier will work with the latest version of go
